### PR TITLE
Fixes #1

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -16,18 +16,22 @@ export default selector => {
 
         function getComponentTagNames (componentSelector) {
             return componentSelector
-        .split(' ')
-        .filter(el => !!el)
-        .map(el => el.trim().toLowerCase());
+                .split(' ')
+                .filter(el => !!el)
+                .map(el => el.trim().toLowerCase());
         }
 
-        function getComponentTag (instance) {
-            return (
-        instance.$options.name ||
-        instance.$options._componentTag ||
-        instance.$options.__file ||
-        ''
-            );
+        function getComponentTags (instance) {
+            const candidates = [
+                instance.$options.name,
+                instance.$options._name,
+                instance.$options._componentTag,
+                instance.$options.__file
+            ];
+
+            return candidates
+                .filter((e) => e)
+                .map((e) => e.toLowerCase());
         }
 
         function filterNodes (root, tags) {
@@ -50,11 +54,9 @@ export default selector => {
                 }
             }
 
-            walkVueComponentNodes(
-        root,
-        0,
-        (node, tagIndex) => tags[tagIndex] === getComponentTag(node)
-      );
+            walkVueComponentNodes(root, 0, (node, tagIndex) => {
+                return getComponentTags(node).indexOf(tags[tagIndex]) !== -1;
+            });
 
             return foundComponents;
         }


### PR DESCRIPTION
It is working for me:

```
 DONE  Compiled successfully in 12453ms                                 18:35:01

Hash: 68d067cdc98b1a9c33f9
Version: webpack 3.11.0
Time: 12453ms
                                  Asset       Size  Chunks             Chunk Names
layouts/default.95bdc81810aa235ca924.js  584 bytes       0  [emitted]  layouts/default
         vendor.38cf135a3c699826acff.js     254 kB       1  [emitted]  vendor
            app.7b6e41bc54f84d1a6d99.js    50.1 kB       2  [emitted]  app
       manifest.68d067cdc98b1a9c33f9.js    1.43 kB       3  [emitted]  manifest
                               LICENSES    1.65 kB          [emitted]  
 + 3 hidden assets
Webpack Bundle Analyzer saved report to /Users/sobolev/Desktop/wemake-vue-demo/.nuxt/dist/report.html
Hash: 6356ae1876f706bc13b1
Version: webpack 3.11.0
Time: 1577ms
             Asset    Size  Chunks             Chunk Names
server-bundle.json  184 kB          [emitted]  
  nuxt:build Building done +16s
 Running tests in:
 - Chrome 63.0.3239 / Mac OS X 10.11.6

 Getting Started
 ✓ nuxt uses correct layout
 ✓ all Comments are present


 2 passed (3s)
✨  Done in 44.00s.
```

Code:

```js
fixture('Getting Started')
  .page('http://localhost:3000')
  .beforeEach(async () => await RootNuxtSelector())

test('nuxt uses correct layout', async (t) => {
  const nuxt = RootNuxtSelector()
  const vm = await nuxt.getVue()

  await t.expect(nuxt.exists).ok()
  await t.expect(vm.state.layoutName).eql('default')
})

test('all Comments are present', async (t) => {
  const comments = RootNuxtSelector('Comment')
  const count = await comments.count

  await t.expect(count).eql(10)
})
```